### PR TITLE
components_header_order

### DIFF
--- a/cpp_standards.md
+++ b/cpp_standards.md
@@ -113,6 +113,8 @@ Exceptions are for replicated functions, which must be written below the replica
 
 Don't move functions around when you add or remove constness, or when you add the `UFUNCTION` macro. This helps code diffs to be minimal.
 
+Components must come first in the properties.
+
 ## [cpp.header.order.cache]
 
 * Try to order data members with cache and alignment in mind.


### PR DESCRIPTION
No need for additional details in `[cpp.init.ctor]` since there is already the sentence: "_Initialize the members in the order they are declared in the header._", which implies that the components should be init first in the ctor since they are declared first in the header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/theemidee/ue4codingstandard/3)
<!-- Reviewable:end -->
